### PR TITLE
Proofread documentation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -162,7 +162,7 @@ contact:
   cc: "John Bacon <two@example.com>"
   bcc: "Eliah Bacon <three@example.com>"
   subject: "Interest in Bacon"
-  body: "Don't forget to add your contact informations :)"
+  body: "Don't forget to add your contact information :)"
   display: "Get in Touch"
 ```
 
@@ -172,7 +172,7 @@ contact:
 ```
 
 ```.language-output
-<a href="mailto:Jane Bacon <one@example.com>?cc=John Bacon <two@example.com>&bcc=Eliah Bacon <three@example.com>&subject=Interest in Bacon&body=Don't forget to add your contact informations :)" class="link email-link">Get in Touch</a>
+<a href="mailto:Jane Bacon <one@example.com>?cc=John Bacon <two@example.com>&bcc=Eliah Bacon <three@example.com>&subject=Interest in Bacon&body=Don't forget to add your contact information :)" class="link email-link">Get in Touch</a>
 ```
 
 ## The modifier
@@ -202,7 +202,7 @@ contact:
   cc: "John Bacon <two@example.com>"
   bcc: "Eliah Bacon <three@example.com>"
   subject: "Interest in Bacon"
-  body: "Don't forget to add your contact informations :)"
+  body: "Don't forget to add your contact information :)"
   display: "Get in Touch"
 ```
 
@@ -212,7 +212,7 @@ contact:
 ```
 
 ```.language-output
-<a href="mailto:Jane Bacon <one@example.com>?cc=John Bacon <two@example.com>&bcc=Eliah Bacon <three@example.com>&subject=Interest in Bacon&body=Don't forget to add your contact informations :)">Get in Touch</a>
+<a href="mailto:Jane Bacon <one@example.com>?cc=John Bacon <two@example.com>&bcc=Eliah Bacon <three@example.com>&subject=Interest in Bacon&body=Don't forget to add your contact information :)">Get in Touch</a>
 ```
 
 ## The API
@@ -236,7 +236,7 @@ $mailto->email = "Jane Bacon <one@example.com>";
 $mailto->cc = "John Bacon <two@example.com>";
 $mailto->bcc = "Eliah Bacon <three@example.com>";
 $mailto->subject = "Interest in Bacon";
-$mailto->body = "Don't forget to add your contact informations :)";
+$mailto->body = "Don't forget to add your contact information :)";
 $mailto->display = "Get in Touch";
 
 /**
@@ -253,7 +253,7 @@ echo $mailto->html();
 ```
 
 ```.language-output
-<a href="mailto:Jane Bacon <one@example.com>?cc=John Bacon <two@example.com>&bcc=Eliah Bacon <three@example.com>&subject=Interest in Bacon&body=Don't forget to add your contact informations :)">Get in Touch</a>
+<a href="mailto:Jane Bacon <one@example.com>?cc=John Bacon <two@example.com>&bcc=Eliah Bacon <three@example.com>&subject=Interest in Bacon&body=Don't forget to add your contact information :)">Get in Touch</a>
 ```
 
 ## Migrating from Version 1

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -12,7 +12,7 @@ Argument | Description
 
 ## Data format for `email`, `cc` and `bcc`
 
-You can use any email notation an email client would understand, you can even use multiple addresses seperated by comma.
+You can use any email notation an email client would understand, you can even use multiple addresses separated by comma.
 
 ```
 {{ mailto_link email="mail@example.com" display="Get in Touch" }}
@@ -51,10 +51,10 @@ contact: "mail@example.com"
 
 ### Multiple email addresses
 
-If you have a list of email addresses you can loop over them like you would normaly do.
+If you have a list of email addresses you can loop over them like you would normally do.
 
 ```.language-yaml
-contacts: 
+contacts:
   - "one@example.com"
   - "two@example.com"
 ```
@@ -224,7 +224,7 @@ In another addon, you may do `$this->api('MailtoLink')->create()` to get a `Mail
 
 /**
  * MailtoLinkModel constructor.
- * 
+ *
  * @param array $parameters
  */
 $mailto = $this->api('MailtoLink')->create()


### PR DESCRIPTION
These changes are in response to Issue #5 

Spelling changes occur in two different commits

-  Line 15 - "separated" and line 54 - "normally"
-  Removing the "s" at the end of "informations." This makes it easier for you to omit this commit if you prefer the original spelling